### PR TITLE
Fix code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/trustly/services/mongo_manager/mongo_controller.py
+++ b/trustly/services/mongo_manager/mongo_controller.py
@@ -49,7 +49,7 @@ class mongo_controller:
       return True, MANAGE_MONGO_MESSAGES.S_INSERT_SUCCESS
     except Exception as ex:
       log.g().e("MONGO E2 : " + MANAGE_MONGO_MESSAGES.S_INSERT_FAILURE + " : " + str(ex))
-      return False, str(ex)
+      return False, MANAGE_MONGO_MESSAGES.S_INSERT_FAILURE
 
   def __read(self, p_data, p_skip, p_limit):
     try:
@@ -60,7 +60,7 @@ class mongo_controller:
       return documents, total_count, True
     except Exception as ex:
       log.g().e("MONGO E3 : " + MANAGE_MONGO_MESSAGES.S_READ_FAILURE + " : " + str(ex))
-      return str(ex), 0, False
+      return MANAGE_MONGO_MESSAGES.S_READ_FAILURE, 0, False
 
   def __replace(self, p_data, p_upsert):
     try:
@@ -78,7 +78,7 @@ class mongo_controller:
 
     except Exception as ex:
       log.g().e("MONGO E4 : " + MANAGE_MONGO_MESSAGES.S_UPDATE_FAILURE + " : " + str(ex))
-      return False, str(ex)
+      return False, MANAGE_MONGO_MESSAGES.S_UPDATE_FAILURE
 
   def __delete(self, p_data):
     try:
@@ -86,7 +86,7 @@ class mongo_controller:
       return documents, MANAGE_MONGO_MESSAGES.S_DELETE_SUCCESS
     except Exception as ex:
       log.g().e("MONGO E5 : " + MANAGE_MONGO_MESSAGES.S_DELETE_FAILURE + " : " + str(ex))
-      return False, str(ex)
+      return False, MANAGE_MONGO_MESSAGES.S_DELETE_FAILURE
 
   def invoke_trigger(self, p_commands, p_data=None):
     pass


### PR DESCRIPTION
Fixes [https://github.com/msmannan00/Orion-Search/security/code-scanning/17](https://github.com/msmannan00/Orion-Search/security/code-scanning/17)

To fix the problem, we need to ensure that exception messages are not returned directly to the user. Instead, we should log the exception details and return a generic error message. This can be achieved by modifying the methods in the `mongo_controller` class to log the exceptions and return a generic error message.

1. Modify the `__create`, `__read`, `__update`, and `__delete` methods in the `mongo_controller` class to log the exception details and return a generic error message.
2. Ensure that the `__fetch_list` method in the `directory_model` class continues to return a generic error message as it currently does.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
