### PR TITLE
Fix code scanning alert no. 28: Information exposure through an exception

### DIFF
--- a/trustly/app/view_managers/interactive/directory_manager/directory_model.py
+++ b/trustly/app/view_managers/interactive/directory_manager/directory_model.py
@@ -57,7 +57,10 @@ class directory_model(request_handler):
       return JsonResponse(response_data)
 
     except Exception as ex:
-      return JsonResponse({"error": "An internal error occurred."+str(ex)}, status=500)
+      # Log the detailed exception message
+      import logging
+      logging.error("An error occurred in __api_directory: %s", str(ex))
+      return JsonResponse({"error": "An internal error occurred."}, status=500)
 
   def __init_page(self, p_data):
     m_directory_class_model, m_status, _ = self.__m_session.invoke_trigger(DIRECTORY_SESSION_COMMANDS.M_PRE_INIT, [p_data])


### PR DESCRIPTION
Fixes [https://github.com/msmannan00/Orion-Search/security/code-scanning/28](https://github.com/msmannan00/Orion-Search/security/code-scanning/28)

To fix the problem, we should avoid exposing the exception details to the end user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

- Modify the exception handling block in the `__api_directory` method to log the exception details and return a generic error message.
- Ensure that the logging mechanism is in place to capture the detailed exception information for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
