### PR TITLE
Potential fix for code scanning alert no. 82: Information exposure through an exception

### DIFF
--- a/backend/orion/api/server/crawl_manager/crawl_model.py
+++ b/backend/orion/api/server/crawl_manager/crawl_model.py
@@ -203,7 +203,11 @@ class crawl_model:
                 return {"error": "File not found"}
             return FileResponse(path=file_path, filename=filename, media_type="image/webp")
         except Exception as e:
-            return {"error": f"Failed to retrieve screenshot: {str(e)}"}
+            # Log the exception details for debugging purposes
+            import logging
+            logging.error(f"Error retrieving screenshot file '{filename}': {str(e)}", exc_info=True)
+            # Return a generic error message to the user
+            return {"error": "An internal error occurred while retrieving the screenshot."}
 
     @staticmethod
     async def invoke_file_upload(payload: ScreenshotPayload):


### PR DESCRIPTION
Potential fix for [https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/82](https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/82)

To fix the issue, we need to ensure that no sensitive information is exposed to the user in the event of an exception. Instead of returning the exception message (`str(e)`) to the user, we should log the exception details on the server for debugging purposes and return a generic error message to the user. This approach ensures that developers can still diagnose issues while protecting the application's internal details from being exposed.

The changes will involve:
1. Modifying the `get_screenshot_file` method in `crawl_model` to log the exception details and return a generic error message.
2. Ensuring that the `get_screenshot` endpoint in `api_routes.py` properly handles the updated response from `get_screenshot_file`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
