### PR TITLE
Potential fix for code scanning alert no. 658: Information exposure through an exception

### DIFF
--- a/backend/orion/api/server/geo_fencing_manager/geo_fencing_manager.py
+++ b/backend/orion/api/server/geo_fencing_manager/geo_fencing_manager.py
@@ -212,7 +212,10 @@ class geo_fencing_manager:
             )
 
             if not m_status:
-                break
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Failed to stream map entities"
+                )
 
             body = docs.body if hasattr(docs, "body") else docs
 

--- a/backend/orion/services/elastic_manager/elastic_controller.py
+++ b/backend/orion/services/elastic_manager/elastic_controller.py
@@ -263,7 +263,7 @@ class elastic_controller:
             return True, m_data
         except Exception as ex:
             log.g().e(f"ELASTIC : {MANAGE_ELASTIC_MESSAGES.S_READ_FAILURE} : {str(ex)}")
-            return False, str(ex)
+            return False, None
 
     @staticmethod
     def _read_index(i: str) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/658](https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/658)

General fix approach: never return raw exception content from lower-level service methods when that content can be forwarded to API responses. Instead, log full details server-side and return/raise sanitized errors for user-facing layers.

Best fix here with minimal behavior change:
1. In `backend/orion/services/elastic_manager/elastic_controller.py`, change `search_query` error path from returning `False, str(ex)` to returning `False, None` (or another non-sensitive sentinel). Keep server logging for diagnostics.
2. In `backend/orion/api/server/geo_fencing_manager/geo_fencing_manager.py`, when `m_status` is false, raise a generic `HTTPException(500, "Failed to stream map entities")` instead of silently breaking. This ensures controlled, sanitized API error behavior and avoids accidental use of tainted `docs`.
3. No route-level changes are required beyond existing handling.

This removes exception-message data flow to the stream while preserving intended functionality (successful stream still works; failures now fail explicitly with generic message).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
