### PR TITLE
Potential fix for code scanning alert no. 617: Uncontrolled data used in path expression

### DIFF
--- a/backend/orion/api/server/crawl_manager/crawl_model.py
+++ b/backend/orion/api/server/crawl_manager/crawl_model.py
@@ -398,10 +398,16 @@ class crawl_model:
     @staticmethod
     async def get_screenshot_file(filename: str):
         try:
-            file_path = os.path.join(CRAWL_PATHS.M_SCREENSHOT, filename)
-            if not os.path.exists(file_path):
+            screenshot_root = Path(CRAWL_PATHS.M_SCREENSHOT).resolve()
+            requested_path = (screenshot_root / filename).resolve()
+            try:
+                requested_path.relative_to(screenshot_root)
+            except ValueError:
                 return {"error": "File not found"}
-            return FileResponse(path=file_path, filename=filename, media_type="image/webp")
+
+            if not requested_path.exists():
+                return {"error": "File not found"}
+            return FileResponse(path=str(requested_path), filename=filename, media_type="image/webp")
         except Exception:
             return {"error": "Failed to retrieve screenshot"}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/617](https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/617)

Use canonical path validation to ensure resolved file paths always stay within `CRAWL_PATHS.M_SCREENSHOT`.

Best fix (without changing functionality): in `get_screenshot_file` (in `backend/orion/api/server/crawl_manager/crawl_model.py`), replace raw `os.path.join(...)` usage with `pathlib.Path.resolve()` checks:

- Resolve the screenshot root directory to an absolute canonical path.
- Resolve the requested file path against that root.
- Reject the request if the resolved file is not inside the root (using `relative_to` check).
- Keep existing behavior for not found files and successful `FileResponse`.

This preserves the same endpoint contract while preventing directory traversal. No new dependency is required since `Path` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
