### PR TITLE
Potential fix for code scanning alert no. 44: Uncontrolled data used in path expression

### DIFF
--- a/backend/interface.py
+++ b/backend/interface.py
@@ -11,7 +11,12 @@ ANGULAR_BUILD_DIR = (BASE_DIR / "build").resolve()
 
 @interface.get("/{full_path:path}", include_in_schema=False)
 async def serve_frontend(full_path: str):
-    requested_path = (ANGULAR_BUILD_DIR / full_path).resolve()
+    user_path = Path(full_path)
+    if user_path.is_absolute() or ".." in user_path.parts:
+        raise HTTPException(status_code=404, detail="Frontend not found")
+
+    safe_relative_path = Path(*[part for part in user_path.parts if part not in ("", ".")])
+    requested_path = (ANGULAR_BUILD_DIR / safe_relative_path).resolve()
     if requested_path.is_relative_to(ANGULAR_BUILD_DIR) and requested_path.exists() and requested_path.is_file():
         return FileResponse(requested_path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/44](https://github.com/Orion-Intelligence/Orion-Intelligence/security/code-scanning/44)

To fix this class of issue, ensure user input is treated as a *relative* path only, reject absolute/traversal segments, and only then join it under a trusted base directory. Keep a final containment check before reading/serving.

Best fix for `backend/interface.py`:
- In `serve_frontend`, parse `full_path` as a `Path`.
- Reject if it is absolute or contains `".."` segments.
- Rebuild `requested_path` from safe relative parts under `ANGULAR_BUILD_DIR`, then resolve.
- Keep the existing `is_relative_to`, `exists`, and `is_file` checks before `FileResponse`.

This keeps behavior the same for valid frontend assets while explicitly rejecting malicious inputs and addressing CodeQL’s taint flow concern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
